### PR TITLE
Use new style endpoints and allow use of dualstack

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -344,7 +344,8 @@ class Configuration
 	}
 
 	/**
-	 * Should we use the dualstack URL (which will ship traffic over ipv6 in most cases)
+	 * Should we use the dualstack URL (which will ship traffic over ipv6 in most cases). For more information on these
+	 * endpoints please read https://docs.aws.amazon.com/AmazonS3/latest/dev/dual-stack-endpoints.html
 	 *
 	 * @return  boolean
 	 */

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -60,6 +60,13 @@ class Configuration
 	protected $useSSL = true;
 
 	/**
+	 * Should I use SSL (HTTPS) to communicate to Amazon S3?
+	 *
+	 * @var  bool
+	 */
+	protected $useDualstackUrl = false;
+
+	/**
 	 * Should I use legacy, path-style access to the bucket? When it's turned off (default) we use virtual hosting style
 	 * paths which are RECOMMENDED BY AMAZON per http://docs.aws.amazon.com/AmazonS3/latest/API/APIRest.html
 	 *
@@ -306,7 +313,8 @@ class Configuration
 
 	/**
 	 * Should I use legacy, path-style access to the bucket? You should only use it with custom endpoints. Amazon itself
-	 * does not support path-style access since September 2020.
+	 * is currently deprecating support for path-style access but has extended the migration date to an unknown
+	 * time https://aws.amazon.com/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/
 	 *
 	 * @return  boolean
 	 */
@@ -333,5 +341,25 @@ class Configuration
 		{
 			$this->useLegacyPathStyle = false;
 		}
+	}
+
+	/**
+	 * Should we use the dualstack URL (which will ship traffic over ipv6 in most cases)
+	 *
+	 * @return  boolean
+	 */
+	public function getDualstackUrl()
+	{
+		return $this->useDualstackUrl;
+	}
+
+	/**
+	 * Set the flag for using legacy, path-style access to the bucket
+	 *
+	 * @param  boolean  $useLegacyPathStyle
+	 */
+	public function setUseDualstackUrl($useDualstackUrl)
+	{
+		$this->useDualstackUrl = $useDualstackUrl;
 	}
 }

--- a/src/Request.php
+++ b/src/Request.php
@@ -718,29 +718,32 @@ class Request
 
 		/**
 		 * When using the Amazon S3 with the v4 signature API we have to use a different hostname per region. The
-		 * mapping can be found in http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
+		 * mapping can be found in https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_region
 		 *
-		 * This means changing the endpoint to s3-REGION.amazonaws.com with the following exceptions:
-		 * For us-east-1: s3-external-1.amazonaws.com
+		 * This means changing the endpoint to s3.REGION.amazonaws.com with the following exceptions:
 		 * For China: s3.REGION.amazonaws.com.cn
 		 *
 		 * v4 signing does NOT support non-Amazon endpoints.
 		 */
 
 		// Most endpoints: s3-REGION.amazonaws.com
-		$endpoint = 's3-' . $region . '.amazonaws.com';
-
-		// Exception: US East 1 endpoint is s3-external-1.amazonaws.com, NOT s3-us-east-1.amazonaws.com
-		if ($region == 'us-east-1')
-		{
-			$endpoint = 's3-external-1.amazonaws.com';
-		}
+		$regionalEndpoint = $region . '.amazonaws.com';
 
 		// Exception: China
 		if (substr($region, 0, 3) == 'cn-')
 		{
 			// Chinese endpoint, e.g.: s3.cn-north-1.amazonaws.com.cn
-			$endpoint = 's3.' . $region . '.amazonaws.com.cn';
+			$regionalEndpoint = $regionalEndpoint . '.cn';
+		}
+
+		// If dual-stack URLs are enabled then prepend the endpoint
+		if ($configuration->getDualstackUrl())
+		{
+			$endpoint = 's3.dualstack.' . $regionalEndpoint;
+		}
+		else
+		{
+			$endpoint = 's3.' . $regionalEndpoint;
 		}
 
 		// Legacy path style access: return just the endpoint


### PR DESCRIPTION
My main aim here was to allow use of dualstack URLs for the downloads site (yes I can just directly apply as I know you don't use it in ARS anymore but trying to contribute back given all you do for the project).

Upon embarking on this looks like AWS urls have changed again since you last changed the code here so I've updated. I'm not 100% on legacy paths whether this URL style works so you definitely should do some additional testing. But you can see the URLs I've referenced when writing this code

I'm also unsure whether I should update the 'bucketless' URLs at the top of the `getHostName` endpoint for China (I don't have a china bucket on the Joomla account to test with :) looks like that definitely supports the s3 prefix now - it just requires a .cn suffix on the URL)