### PR TITLE
Set the signature before trying to unset the region to avoid an exception

### DIFF
--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -199,6 +199,8 @@ class Configuration
 			throw new Exception\InvalidSignatureMethod;
 		}
 
+		$this->signatureMethod = $signatureMethod;
+
 		// If you switch to v2 signatures we unset the region.
 		if ($signatureMethod == 'v2')
 		{
@@ -215,8 +217,6 @@ class Configuration
 			}
 
 		}
-
-		$this->signatureMethod = $signatureMethod;
 	}
 
 	/**


### PR DESCRIPTION
The library will [automatically change](https://github.com/akeeba/s3/blob/416d2be906064c956a812797d76bab7d8ae93be3/src/Configuration.php#L294-L301) the signature to `v2` when the endpoint doesn't match `amazonaws.com`. It makes a call to `setSignatureMethod`, which calls `setRegion` [with an empty string](https://github.com/akeeba/s3/blob/416d2be906064c956a812797d76bab7d8ae93be3/src/Configuration.php#L200-L202) to unset the region _before_ it updates the `signatureMethod` property to `v2`, which in turn [throws an exception](https://github.com/akeeba/s3/blob/416d2be906064c956a812797d76bab7d8ae93be3/src/Configuration.php#L239-L242).

Thanks to @jrahmy for catching this. 🙂 