### PR TITLE
Explode __responseHeaderCallback data on colon only

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -604,7 +604,7 @@ class Request
 			return $strlen;
 		}
 
-		[$header, $value] = explode(': ', trim($data), 2);
+		[$header, $value] = explode(':', trim($data), 2);
 		$header = trim($header ?? '');
 		$value  = trim($value ?? '');
 


### PR DESCRIPTION
The space after the colon appears to cause issues with headers generated by Digital Ocean Spaces (not entirely sure which header). The header passes the previous check (line 602) but does not include a space after the colon so is not split, resulting in an error in the assignment.