### PR TITLE
Add configurable connection and request timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,3 +366,21 @@ If you are using a third party service which for any reason does not understand 
 ```php
 $configuration->setUseHTTPDateHeader(true);
 ```
+
+### Connection and request timeouts
+
+By default, the connector does not impose any explicit time limit on its HTTP requests; the underlying cURL defaults apply. You can set two independent timeouts, both expressed in whole seconds:
+
+```php
+// Give up if the connection to the endpoint is not established within 10 seconds
+$configuration->setConnectTimeout(10);
+
+// Give up if the entire request has not completed within 120 seconds
+$configuration->setRequestTimeout(120);
+```
+
+`setConnectTimeout()` limits only the time spent establishing the connection to the S3 endpoint. `setRequestTimeout()` limits the total time allowed for the whole request, including the transfer of the request and response bodies.
+
+A value of `0` (the default) means no explicit limit is applied. Negative values are clamped to `0`.
+
+Caveat: `setRequestTimeout()` applies to the request as a whole. When you are uploading or downloading large objects you must allow enough time for the transfer to complete, otherwise the request will be aborted mid-transfer. If in doubt, leave it at its default of `0` (no limit).

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -110,6 +110,22 @@ class Configuration
 	protected $preSignedBucketInURL = false;
 
 	/**
+	 * Maximum time, in seconds, to wait while trying to establish the connection to the S3 endpoint. A value of 0
+	 * (default) means no explicit limit, i.e. cURL's own default is used.
+	 *
+	 * @var  int
+	 */
+	protected $connectTimeout = 0;
+
+	/**
+	 * Maximum time, in seconds, allowed for the entire request to complete. A value of 0 (default) means no explicit
+	 * limit, i.e. the request is allowed to run for as long as it takes.
+	 *
+	 * @var  int
+	 */
+	protected $requestTimeout = 0;
+
+	/**
 	 * Public constructor
 	 *
 	 * @param   string  $access           Amazon S3 Access Key
@@ -443,5 +459,51 @@ class Configuration
 	public function setPreSignedBucketInURL(bool $preSignedBucketInURL): void
 	{
 		$this->preSignedBucketInURL = $preSignedBucketInURL;
+	}
+
+	/**
+	 * Get the maximum time, in seconds, to wait while establishing the connection to the S3 endpoint.
+	 *
+	 * @return  int  Timeout in seconds; 0 means no explicit limit.
+	 */
+	public function getConnectTimeout(): int
+	{
+		return $this->connectTimeout;
+	}
+
+	/**
+	 * Set the maximum time, in seconds, to wait while establishing the connection to the S3 endpoint.
+	 *
+	 * @param   int  $connectTimeout  Timeout in seconds; 0 (or any negative value, which is clamped to 0) means no
+	 *                                explicit limit.
+	 *
+	 * @return  void
+	 */
+	public function setConnectTimeout(int $connectTimeout): void
+	{
+		$this->connectTimeout = max(0, $connectTimeout);
+	}
+
+	/**
+	 * Get the maximum time, in seconds, allowed for the entire request to complete.
+	 *
+	 * @return  int  Timeout in seconds; 0 means no explicit limit.
+	 */
+	public function getRequestTimeout(): int
+	{
+		return $this->requestTimeout;
+	}
+
+	/**
+	 * Set the maximum time, in seconds, allowed for the entire request to complete.
+	 *
+	 * @param   int  $requestTimeout  Timeout in seconds; 0 (or any negative value, which is clamped to 0) means no
+	 *                                explicit limit.
+	 *
+	 * @return  void
+	 */
+	public function setRequestTimeout(int $requestTimeout): void
+	{
+		$this->requestTimeout = max(0, $requestTimeout);
 	}
 }

--- a/src/Request.php
+++ b/src/Request.php
@@ -400,6 +400,20 @@ class Request
 		$curl = curl_init();
 		curl_setopt($curl, CURLOPT_USERAGENT, 'AkeebaBackupProfessional/S3PostProcessor');
 
+		// Apply the optional connection and request timeouts. A value of 0 means "no explicit limit".
+		$connectTimeout = $this->configuration->getConnectTimeout();
+		$requestTimeout = $this->configuration->getRequestTimeout();
+
+		if ($connectTimeout > 0)
+		{
+			curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, $connectTimeout);
+		}
+
+		if ($requestTimeout > 0)
+		{
+			curl_setopt($curl, CURLOPT_TIMEOUT, $requestTimeout);
+		}
+
 		if ($this->configuration->isSSL())
 		{
 			// Set the CA certificate cache location


### PR DESCRIPTION
Two new Configuration options let consumers bound how long a request may take, without depending on cURL-specific naming:

- setConnectTimeout()/getConnectTimeout() maps to CURLOPT_CONNECTTIMEOUT and limits the connection-establishment phase.
- setRequestTimeout()/getRequestTimeout() maps to CURLOPT_TIMEOUT and limits the entire request.

Both are expressed in whole seconds and default to 0, meaning "no explicit limit" so existing behaviour is unchanged. Negative values are clamped to 0. The cURL options are only set when the value is greater than 0.